### PR TITLE
Use a more appropriate macro to check tz support

### DIFF
--- a/src/pTOTP.c
+++ b/src/pTOTP.c
@@ -215,7 +215,7 @@ void show_no_tokens_message(bool show) {
 void refresh_all(void){
   static unsigned int lastQuantizedTimeGenerated = 0;
 
-#ifndef PBL_PLATFORM_APLITE
+#ifdef PBL_SDK_3
   unsigned long utcTime = time(NULL);
 #else
   unsigned long utcTime = time(NULL) - utc_offset;


### PR DESCRIPTION
Aplite has been giving UTC time since SDK 3.8, and Diorite is also picking up on this bug via aplite backwards compatibility. This causes Authenticator to be very confused on tintin, bianca and silk.

(It would be more correct to use `clock_is_timezone_set` but I'm lazy. I'm also so lazy I haven't even tried building this.)