### PR TITLE
Support arbitrary code lengths.  Fixes #11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ While I have done my best to guard the credentials you enter in this application
 
 # Build it yourself
 Nothing more than the standard [Pebble 2.0 SDK](https://developer.getpebble.com/2/getting-started/) is required to build and run this app. You may wish to change the configuration page URL in the `showConfiguration` event handler to point at a local development server.
+
+# Features
+Forked from https://github.com/cpfair/pTOTP 
+* Google Authenticator compatible verification codes
+* SHA256 for AWS 64 character keys
+
+This repo adds:
+* Specify code length (default 6, supports Battle.net codes by specifying 8)
+* Adds a space in the middle of the code when using more than 6 digits

--- a/appinfo.json
+++ b/appinfo.json
@@ -4,6 +4,7 @@
         "AMCreateToken": 1,
         "AMCreateToken_ID": 2,
         "AMCreateToken_Name": 3,
+        "AMCreateToken_Digits": 11,
         "AMDeleteToken": 4,
         "AMReadTokenList": 6,
         "AMReadTokenList_Finished": 8,
@@ -36,8 +37,8 @@
         "chalk"
     ],
     "uuid": "da96ea4e-7793-4301-9d9a-68714a902730",
-    "versionCode": 11,
-    "versionLabel": "1.11",
+    "versionCode": 12,
+    "versionLabel": "1.12",
     "watchapp": {
         "watchface": false
     }

--- a/src/generate.c
+++ b/src/generate.c
@@ -40,8 +40,6 @@
 #include "sha256.h"
 #include "hmac.h"
 
-#define VERIFICATION_CODE_MODULUS (1000*1000) // Six digits
-
 int generateCode(uint8_t *secret, uint8_t secret_length, unsigned long tm) {
   uint8_t challenge[8];
   for (int i = 8; i--; tm >>= 8) {
@@ -73,7 +71,6 @@ int generateCode(uint8_t *secret, uint8_t secret_length, unsigned long tm) {
 
   // Truncate to a smaller number of digits.
   truncatedHash &= 0x7FFFFFFF;
-  truncatedHash %= VERIFICATION_CODE_MODULUS;
 
   return truncatedHash;
 }

--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -71,7 +71,7 @@ var OpenConfiguration = function(){
     // You used to be able to defer opening the config page till the tokens were loaded.
     // You can't any more...
     if (TokenLoadFinished) {
-        Pebble.openURL("https://pebbleauth.cpfx.ca/config.html?ver=1.1.0#" + encodeURIComponent(JSON.stringify(Tokens)));
+        Pebble.openURL("https://pebbleauth.cpfx.ca/config.html?ver=1.12#" + encodeURIComponent(JSON.stringify(Tokens)));
     } else {
         Pebble.openURL("https://pebbleauth.cpfx.ca/relaunch.html");
     }
@@ -117,7 +117,7 @@ var ReconcileConfiguration = function(newTokens) {
         token = to_create[idx];
 		var secretArray = ToByteArray(atob(token.Secret));
 		secretArray.unshift(secretArray.length);
-        QueueAppMessage({"AMCreateToken": secretArray, "AMCreateToken_ID": token.ID, "AMCreateToken_Name": token.Name});
+        QueueAppMessage({"AMCreateToken": secretArray, "AMCreateToken_ID": token.ID, "AMCreateToken_Name": token.Name, "AMCreateToken_Digits": token.Digits});
     }
     for (idx in to_update) {
         token = to_update[idx];

--- a/src/pTOTP.c
+++ b/src/pTOTP.c
@@ -68,7 +68,7 @@ typedef struct TokenInfo {
   short id;
   uint8_t secret_length; // Since persistence is limited to this size anyways.
   uint8_t* secret;
-  char code[11];
+  char code[12];
   short digits;
 } TokenInfo;
 
@@ -203,8 +203,21 @@ void publicinfo2tokeninfo(PublicTokenInfo* public, TokenInfo* key) {
 }
 
 void code2char(unsigned int code, char* out, int length) {
+  out[length] = 0;
   for(int x=0; x<length; x++) {
     out[length-1-x] = '0' + (code % 10);
+    code /= 10;
+  }
+}
+
+void code2charspace(unsigned int code, char* out, int length) {
+  out[length+1] = 0;
+  for(int x=0; x<=length; x++) {
+    if (x == length/2) {
+      out[length-x] = ' ';
+      x++;
+    }
+    out[length-x] = '0' + (code % 10);
     code /= 10;
   }
 }
@@ -238,7 +251,11 @@ void refresh_all(void){
   TokenListNode* keyNode = token_list;
   while (keyNode) {
     unsigned int code = generateCode(keyNode->key->secret, keyNode->key->secret_length, quantized_time);
-    code2char(code, (char*)&keyNode->key->code, keyNode->key->digits);
+    if (keyNode->key->digits > 6) {
+      code2charspace(code, (char*)&keyNode->key->code, keyNode->key->digits);
+    } else {
+      code2char(code, (char*)&keyNode->key->code, keyNode->key->digits);
+    }
     keyNode = keyNode->next;
     hasKeys = true;
   }

--- a/webapp/config.html
+++ b/webapp/config.html
@@ -59,6 +59,8 @@
                     <input type="text" name="new-token-name" id="new-token-name" placeholder="johan@gmail.com" required maxlength="32"/>
                     <label for="new-token-key">Key</label>
                     <input type="text" name="new-token-key" value="" id="new-token-key" placeholder="2XC2E64AAG0T23AR" maxlength="64" required autocapitalize="off" autocorrect="off" autocomplete="off"/>
+                    <label for="new-token-digits">Digits</label>
+                    <input type="text" name="new-token-digits" value="" id="new-token-digits" placeholder="6" maxlength="2" inputmode="numeric" autocorrect="off" autocomplete="off"/>
                 </div>
                 <a class="ui-btn ui-icon-check ui-btn-icon-right" id="token-create-btn">Create Token</a>
         </div>

--- a/webapp/js/config.js
+++ b/webapp/js/config.js
@@ -132,11 +132,15 @@ var TokenCreated = function(e){
     var token = {
         "ID": NextTokenID(),
         "Name": $("#new-token-name").val(),
-        "Secret": base64_secret
+        "Secret": base64_secret,
+        "Digits": parseInt($("#new-token-digits").val())
     };
     if (!token.Name || !token.Secret) {
         alert("You must enter a name and key for the new token");
         return;
+    }
+    if (isNaN(token.Digits) || token.Digits < 1 || token.Digits > 10) {
+        token.Digits = 6;
     }
     Tokens.push(token);
     SetPendingWatchUpdate();


### PR DESCRIPTION
### Support code lengths other than 6.

When adding codes, the default is 6 digits unless otherwise specified.  Max length is 10.*  This bumps the version since the config page is incompatible with the old version.  The new code needs the code lengths and the new config page provides them.  I have not tested the old app with the new config page.  I expect the old code to ignore the lengths and still work.

PR https://github.com/cpfair/pTOTP/pull/6 hardcoded the name and reduced the font size for all codes.  This version reduces the font when needed and provides an optional number of digits on the config page.

* 2^32 = 4294967296.  The first digit is 0-4 so no one would really use 10 digits.  This should cover any use.